### PR TITLE
Fix: Update install prefix to /usr

### DIFF
--- a/debian/files
+++ b/debian/files
@@ -1,2 +1,2 @@
-adwdialog_0.1.6_amd64.buildinfo utils optional
-adwdialog_0.1.6_amd64.deb utils optional
+adwdialog_0.2.0_amd64.buildinfo utils optional
+adwdialog_0.2.0_amd64.deb utils optional

--- a/debian/rules
+++ b/debian/rules
@@ -10,4 +10,4 @@
 #export DH_VERBOSE=1
 
 %:
-	dh $@ --buildsystem=meson
+	dh $@ --buildsystem=meson -- --prefix=/usr


### PR DESCRIPTION
- add install prefix to debian/rules
- update debian/files version tag


I wasnt sure if the update to debian files was relevant.  it happened automatically on build.  i can squash it or drop it or leave it as-is.

relates to https://github.com/Vanilla-OS/desktop-image/issues/175